### PR TITLE
Correlation ID generator updatea

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -16,7 +16,7 @@ jobs:
       vmImage: ubuntu-latest
 
     variables:
-      rubyVersion: '= 2.7.3'
+      rubyVersion: '= 2.7.4'
       bundlerVersion: '2.2.15'
 
     steps:

--- a/hwf_hmrc_api.gemspec
+++ b/hwf_hmrc_api.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.description   = "Basic logic to communicate and parse data to/from HMRC API."
   spec.homepage      = "https://github.com/hmcts/hwf_hmrc_api"
   spec.license       = "MIT"
-  spec.required_ruby_version = Gem::Requirement.new(">= 2.7.0")
+  spec.required_ruby_version = Gem::Requirement.new(">= 2.7.4")
 
   spec.metadata["homepage_uri"] = spec.homepage
   spec.metadata["source_code_uri"] = "https://github.com/ministryofjustice/glimr-api-client"

--- a/lib/hwf_hmrc_api/endpoint.rb
+++ b/lib/hwf_hmrc_api/endpoint.rb
@@ -25,7 +25,7 @@ module HwfHmrcApi
           "Content-Type": "application/json",
           "Accept" => "application/vnd.hmrc.#{version}+json",
           "Authorization" => "Bearer #{access_token}",
-          "correlationId" => UUID.new.generate
+          "correlationId" => SecureRandom.uuid
         }
       end
 

--- a/lib/hwf_hmrc_api/endpoint/user_matching.rb
+++ b/lib/hwf_hmrc_api/endpoint/user_matching.rb
@@ -6,7 +6,7 @@ module HwfHmrcApi
       def match_user(access_token, user_info)
         @response = HTTParty.post("#{api_url}/individuals/matching",
                                   headers: { "Content-Type": "application/json",
-                                             "correlationId" => UUID.new.generate,
+                                             "correlationId" => SecureRandom.uuid,
                                              "Accept" => "application/vnd.hmrc.2.0+json",
                                              "Authorization" => "Bearer #{access_token}" },
                                   body: user_info.to_json)


### PR DESCRIPTION
For some reason  UUID.new.generate  stopped generating valid Correlation ID even thought it still fit the regex described in HMRC documentation.